### PR TITLE
Revert "run CI tests on macos-latest"

### DIFF
--- a/.github/workflows/package_startup_tests.yml
+++ b/.github/workflows/package_startup_tests.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   macos-test-dmg:
-    runs-on: macos-latest
+    runs-on: macos-11
     if: ${{ true }}
     permissions:
       contents: write


### PR DESCRIPTION
This reverts commit 7454125ae8dee766771c84e1e1bb14eb218439d4.