### PR TITLE
Obsolete version. DO NOT USE THIS VERSION ANYMORE.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -234,7 +234,7 @@ tasks.withType<org.gradle.jvm.tasks.Jar> {
 
 tasks {
     val downloadAppImageBuilder by registering(Download::class) {
-        src("https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage")
+        src("https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage")
         dest(appImageTool)
         overwrite(false)
         doFirst {


### PR DESCRIPTION
Please switch to the new version at
https://github.com/AppImage/appimagetool/releases/tag/continuous

If this causes issues in your CI workflow you are unable to resolve, please comment here so that we can help you.